### PR TITLE
fix(seeders): transactions seeders fixed

### DIFF
--- a/database/seeders/20221204153148-transactions.js
+++ b/database/seeders/20221204153148-transactions.js
@@ -4,16 +4,18 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     return await queryInterface.bulkInsert("Transactions", [
       {
-        description: "Some description",
-        amount: 500.1,
+        description: "User #1 charged himself $500",
+        amount: 500,
         userId: 1,
         categoryId: 1,
+        toUserId: 1,
       },
       {
-        description: "Some diferent description",
-        amount: 500.1,
-        userId: 2,
+        description: "User #2 receive $250 from User #1",
+        amount: 250,
+        userId: 1,
         categoryId: 2,
+        toUserId: 2,
       },
     ]);
   },


### PR DESCRIPTION
## No ticket
## Description
AS: Developer
I Want: to create transactions seeders
To: be able to use it 

## Evidence:
### Before: 
The two starter transactions in seeders are being generated with null values in toUserId
![image](https://user-images.githubusercontent.com/87744456/207436550-5731b9dc-7d9c-4961-8d74-e9a84e132b4b.png)
### After
![image](https://user-images.githubusercontent.com/87744456/207437034-524187e4-4bf6-4bfc-b5f8-24093fa75b3a.png)


